### PR TITLE
Merge feature/sensible-defaults

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -195,13 +195,21 @@ fn buildTests(b: *Build, lib_mod: *Module, deps: Dependencies, opts: BuildOpts) 
         .root_module = lib_mod,
         .target = opts.target,
     });
+
+    const common_tests = b.addTest(.{
+        .name = "common unit tests",
+        .root_module = deps.common,
+        .target = opts.target,
+    });
     b.installArtifact(test_comp);
+    b.installArtifact(common_tests);
 
     const test_step = b.addRunArtifact(test_comp);
+    const common_test_step = b.addRunArtifact(common_tests);
     const test_cmd = b.step("run-tests", "run all unit tests");
+    
     test_cmd.dependOn(&test_step.step);
-
-    _ = deps;
+    test_cmd.dependOn(&common_test_step.step);
 }
 // Although this function looks imperative, note that its job is to
 // declaratively construct a build graph that will be executed by an external

--- a/build.zig
+++ b/build.zig
@@ -15,6 +15,7 @@ const Dependencies = struct {
     rshc: *Module,
     vulkan: *Module,
     glfw: *Module,
+    common: *Module,
 };
 
 fn resolveGLFWSystemDeps(m: *Module) void {
@@ -48,10 +49,17 @@ fn buildDeps(b: *Build, opts: BuildOpts) Dependencies {
 
     resolveGLFWSystemDeps(glfw_mod);
 
+    const common_mod = b.createModule(.{
+        .optimize = opts.optimize,
+        .target = opts.target,
+        .root_source_file = b.path("src/common/common.zig"),
+    });
+
     return .{
         .rshc = rshc_mod,
         .vulkan = vulkan_mod,
         .glfw = glfw_mod,
+        .common = common_mod,
     };
 }
 
@@ -69,6 +77,9 @@ fn buildLibrary(
     });
 
     lib_mod.addImport("vulkan", deps.vulkan);
+    lib_mod.addImport("common", deps.common);
+
+    // Temporary for development
     lib_mod.addImport("rshc", deps.rshc);
     lib_mod.addImport("glfw", deps.glfw);
 

--- a/src/api/command_buffer.zig
+++ b/src/api/command_buffer.zig
@@ -113,7 +113,7 @@ pub fn deinit(self: *const Self) void {
 }
 
 const res = @import("../resource_management/res.zig");
-const common = @import("../common/common.zig");
+const common = @import("common");
 
 pub const CommandBuffer = struct {
     h_cmd_buffer: vk.CommandBuffer,

--- a/src/api/image.zig
+++ b/src/api/image.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const vk = @import("vulkan");
 const rsh = @import("rshc");
-const common = @import("common");
 
 const buf = @import("buffer.zig");
 const util = @import("../util.zig");
@@ -55,47 +54,6 @@ pub const Config = struct {
     clear_col: ?vk.ClearColorValue = null,
     staging_buf: ?*StagingBuffer = null,
     initial_layout: vk.ImageLayout = .undefined,
-
-    // Configuration stuff
-    const config = common.config;
-    const ConfigurationRegistry = config.ConfigurationRegistry;
-
-    pub const Profiles = enum {
-        Texture,
-        Storage,
-        Depth,
-    };
-
-    fn configureStorage(cfg: *Config, params: struct {
-        usage_flags: vk.ImageUsageFlags,
-    }) void {}
-
-    fn resolveExtent(swapchain: *const api.Swapchain) vk.Extent2D {
-        return swapchain.extent;
-    }
-
-    const Registry = ConfigurationRegistry(Config, Profiles, .{
-        .Texture = config.Parameterized(Config{
-            .usage = .{
-                .sampled_bit = true,
-            },
-        }, .{
-            .extent = config.Parameter(vk.Extent2D, "swapchain", resolveExtent),
-        }),
-        .Storage = Config{},
-        .Depth = Config{},
-        .Default = Config{},
-    });
-
-    /// const image_cfg = Image.Config.from(.Texture, .{
-    ///     .swapchain = &my_swapchain,
-    /// });
-    /// const image = api.Image.init(&my_context, allocator, image_config);
-
-    pub const from = Registry.BuilderMixin;
-    // this is either a function or a static ref
-    pub const default = Registry.DefaultMixin;
-    pub const profile = Registry.ProfileMixin;
 };
 
 fn createImageMemory(

--- a/src/api/image.zig
+++ b/src/api/image.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const vk = @import("vulkan");
 const rsh = @import("rshc");
+const common = @import("common");
 
 const buf = @import("buffer.zig");
 const util = @import("../util.zig");
@@ -54,6 +55,42 @@ pub const Config = struct {
     clear_col: ?vk.ClearColorValue = null,
     staging_buf: ?*StagingBuffer = null,
     initial_layout: vk.ImageLayout = .undefined,
+
+    // Configuration stuff
+    const config = common.config;
+    const ConfigurationRegistry = config.ConfigurationRegistry;
+
+    pub const Profiles = enum {
+        Texture,
+        Storage,
+        Depth,
+    };
+
+    fn configureStorage(cfg: *Config, params: struct {
+        usage_flags: vk.ImageUsageFlags,
+    }) void {}
+
+    fn resolveExtent(swapchain: *const api.Swapchain) vk.Extent2D {
+        return swapchain.extent;
+    }
+
+    const Registry = ConfigurationRegistry(Config, Profiles, .{
+        .Texture = config.Parameterized(Config{
+            .usage = .{
+                .sampled_bit = true,
+            },
+        }, .{
+            .extent = config.Parameter(vk.Extent2D, "swapchain", resolveExtent),
+        }),
+        .Storage = configureStorage,
+        .Depth = Config{},
+        .Default = Config{},
+    });
+
+    pub const from = Registry.BuilderMixin;
+    // this is either a function or a static ref
+    pub const default = Registry.DefaultMixin;
+    pub const profile = Registry.ProfileMixin;
 };
 
 fn createImageMemory(

--- a/src/api/image.zig
+++ b/src/api/image.zig
@@ -82,10 +82,15 @@ pub const Config = struct {
         }, .{
             .extent = config.Parameter(vk.Extent2D, "swapchain", resolveExtent),
         }),
-        .Storage = configureStorage,
+        .Storage = Config{},
         .Depth = Config{},
         .Default = Config{},
     });
+
+    /// const image_cfg = Image.Config.from(.Texture, .{
+    ///     .swapchain = &my_swapchain,
+    /// });
+    /// const image = api.Image.init(&my_context, allocator, image_config);
 
     pub const from = Registry.BuilderMixin;
     // this is either a function or a static ref

--- a/src/common/common.zig
+++ b/src/common/common.zig
@@ -68,3 +68,8 @@ pub const AnyPtr = struct {
 /// I need right now
 pub fn APIFunction(func: anytype) APIFunctionType(func) {
 }
+
+
+comptime {
+    _ = @import("config.zig");
+}

--- a/src/common/common.zig
+++ b/src/common/common.zig
@@ -5,6 +5,9 @@ const h = @import("handle.zig");
 pub const Handle = h.Handle;
 pub const OpaqueHandle = h.OpaqueHandle;
 
+pub const config = @import("config.zig");
+pub const util = @import("util.zig");
+
 /// This is cursed as hell..
 /// Returns a unique identifier for any type at comptime or runtime
 /// https://github.com/ziglang/zig/issues/19858#issuecomment-2094339450

--- a/src/common/config.zig
+++ b/src/common/config.zig
@@ -1,0 +1,10 @@
+//! Configurations and stuff but cooler
+
+
+pub fn ConfigurationRegistry(
+    comptime ConfigType: type,
+    comptime Profiles: type,
+    comptime profile_defs: anytype,
+) type {
+
+}

--- a/src/common/config.zig
+++ b/src/common/config.zig
@@ -4,7 +4,7 @@ const std = @import("std");
 const util = @import("common.zig").util;
 
 fn validateProfiles(
-    comptime T: type, 
+    comptime T: type,
     comptime Hint: type,
 ) std.builtin.Type.Enum {
     const pinfo = @typeInfo(T);
@@ -19,24 +19,51 @@ fn validateDef(
     comptime T: type,
     comptime def: anytype,
     comptime Hint: type,
-) void {
+) []const std.builtin.Type.StructField {
     const info = @typeInfo(@TypeOf(def));
 
     switch (info) {
         .@"struct" => |*s| {
             const pinfo = @typeInfo(T).@"enum";
             for (pinfo.fields) |fld| {
-                if (util.tryGetField(s, fld.name)) {
+                if (!util.tryGetField(s, fld.name)) {
                     @compileError("Profile def missing field: " ++
                         fld.name ++ " for config type: " ++ @typeName(Hint));
                 }
+            }
+
+            if (!util.tryGetField(s, "Default")) {
+                @compileError("Profile def missing default field " ++
+                    " for config type: " ++ @typeName(Hint));
             }
         },
         else => @compileError("Invalid profile def struct: " ++
             @typeName(T) ++ " for config type: " ++ @typeName(Hint)),
     }
+    return @typeInfo(@TypeOf(def)).@"struct".fields;
 }
 
+
+pub const ParameterDef = struct {
+    OutputType: type,
+    out_fld_name: [:0]const u8,
+    in_fld_name: [:0]const u8,
+
+    InputType: type,
+    resolver: *anyopaque,
+};
+
+fn ProfileDef(comptime ConfigType: type) type {
+    return union(enum) {
+        Valued: struct {
+            PType: type,
+            default_val: ConfigType,
+            // map from field names to all resolver functions (built from param data)
+            resolvers: ?std.StaticStringMap(ParameterDef),
+        },
+        Function,
+    };
+}
 
 pub fn ConfigurationRegistry(
     /// ConfigType can be any struct
@@ -51,22 +78,236 @@ pub fn ConfigurationRegistry(
     comptime profile_defs: anytype,
 ) type {
     const profile_info = validateProfiles(Profiles, ConfigType);
-    validateDef(Profiles, profile_defs, ConfigType);
+    const def_fields = validateDef(Profiles, profile_defs, ConfigType);
 
     const profiles_len = profile_info.fields.len;
+    const ProfileDefType = ProfileDef(ConfigType);
+    comptime var profiles: [profiles_len]ProfileDefType = .{};
+
+    for (def_fields) |fld| {
+        const field_index: usize = if (std.mem.eql(fld.name, "Default") == .eq)
+            @intFromEnum(std.meta.stringToEnum(
+                Profiles,
+                fld.name,
+            ) orelse unreachable)
+        else
+            (profiles_len - 1);
+
+        profiles[field_index] = switch (fld.type) {
+            ParameterizedProfileDef(ConfigType) => blk: {
+                const parameters = @field(profile_defs, fld.name).params;
+
+                comptime var ptype_fields: []std.builtin.Type.StructField = &.{};
+                comptime var resolvers = .{};
+
+                for (parameters) |p| {
+                    ptype_fields = ptype_fields ++ [_]std.builtin.Type.StructField{.{
+                        .name = p.fld_name,
+                        .type = p.InputType,
+                    }};
+
+                    resolvers = resolvers ++ .{p.in_fld_name, p};
+                }
+
+                const PType = @Type(.{
+                    .@"struct" = std.builtin.Type.Struct{
+                        .fields = ptype_fields,
+                    },
+                });
+
+                const default_val = @field(profile_defs, fld.name).default_val;
+
+                break :blk ProfileDefType{ .Valued = .{
+                    .PType = PType,
+                    .default_val = default_val,
+                    .resolvers = std.StaticStringMap(ParameterDef)
+                        .initComptime(resolvers),
+                } };
+            },
+            ConfigType => blk: {
+                const default_val: ConfigType = @field(profile_defs, fld.name);
+
+                break :blk ProfileDefType{ .Valued = .{
+                    .PType = null,
+                    .default_val = default_val,
+                    .resolvers = null,
+                } };
+            },
+            else => {
+                //TODO: Check for a full mapping function signature later
+                @compileError("Invalid profile def entry for type: " ++
+                    @typeName(ConfigType));
+            }
+        };
+    }
+
+    return struct {
+        const Self = @This();
+        const profile_data: []const ProfileDef = profiles[0..profiles_len];
+        const default_index = profiles_len - 1;
+        // TODO: Check presence of fields
+        // and make sure the params are a struct literal.
+        fn comptimeValidate(params: anytype, index: usize) void {
+            comptime {
+                const params_info = @typeInfo(@TypeOf(params));
+                switch (params_info) {
+                    .@"struct" => {},
+                    else => @compileError("Invalid parameter literal: must be struct!"),
+                }
+
+                _ = index;
+            }
+        }
+        pub const ConfigBuilder = struct {
+            underlying: ConfigType,
+            pub fn extend(self: *ConfigBuilder, vals: ConfigType) *ConfigBuilder {
+                inline for (@typeInfo(ConfigType).@"struct".fields) |*fld| {
+                    @field(self.underlying, fld.name) = @field(vals, fld.nam);
+                }
+
+                return self;
+            }
+
+            pub fn combine(self: *ConfigBuilder, profile: Profiles, params: anytype) *ConfigBuilder {
+                const other = Self.ProfileMixin(profile, params);
+                return self.extend(other);
+            }
+
+            pub fn finalize(self: *const ConfigBuilder) ConfigType {
+                return self.underlying;
+            }
+        };
+
+        pub fn BuilderMixin(profile: Profiles, params: anytype) ConfigBuilder {
+            return .{
+                .underlying = setFromProfileIndex(@intFromEnum(profile), params),
+            };
+        }
+
+        fn setFromProfileIndex(index: usize, params: anytype) ConfigType {
+            const profile_def = profile_data[index];
+            return switch (profile_def) {
+                .Valued => |*v| blk: {
+                    var val: ConfigType = v.default_val;
+                    if (v.resolvers) |rmap| {
+                        const ptype_info = @typeInfo(v.PType).@"struct";
+
+                        inline for (ptype_info.fields) |*fld| {
+                            const res = rmap.get(fld.name) orelse unreachable;
+                            @field(val, res.out_fld_name) = @as(*const fn (
+                                res.InputType
+                            ) res.OutputType, @ptrCast(@alignCast(res.resolver)))(
+                                @field(params, res.in_fld_name)
+                            );
+                        }
+                    } 
+
+                    break :blk val;
+                },
+                .Function => @compileError("Function-based profiles currently unsupported!"),
+            };
+        }
+
+        pub fn DefaultMixin(params: anytype) ConfigType {
+            return setFromProfileIndex(default_index, params);
+        }
+
+        pub fn ProfileMixin(profile: Profiles, params: anytype) ConfigType {
+            return setFromProfileIndex(@intFromEnum(profile), params);
+        }
+    };
+}
+
+
+fn ParameterizedProfileDef(comptime ConfigType: type) type {
+    return struct {
+        params: []const ParameterDef,
+        default_value: ConfigType,
+    };
 }
 
 pub fn Parameterized(
     comptime instance: anytype,
     comptime params: anytype,
-) @TypeOf(instance) {}
+) ParameterizedProfileDef(@TypeOf(instance)) {
+    if (@typeInfo(@TypeOf(params)) == .@"struct")
+        @compileError("Invalid parameterset type (must be struct) " ++
+            @typeName(instance));
 
-fn ResolverFn(comptime T: type) type {}
+    const pinfo = @typeInfo(@TypeOf(params)).@"struct";
+    comptime var params2: []ParameterDef = &.{};
 
-pub const ParameterDef = struct {};
+    for (pinfo.fields) |fld| {
+        const val = @field(pinfo, fld.name);
 
+        params2 = params2 ++ [_]ParameterDef{.{
+            .out_fld_name = fld.name,
+
+            .OutputType = val.@"0",
+            .InputType = val.@"1",
+            .in_fld_name = val.@"2",
+            .resolver = val.@"3",
+        }};
+    }
+
+    return .{
+        .params = params2,
+        .default_value = instance,
+    };
+}
+
+// fn ResolverFn(comptime T: type) type {}
+
+// since the output field names are mapped to the left-hand side
+// of an assignment, we need a temporary storage record for the rest of the data.
+// This is mostly for usage ergonomics, there's no actual implementation reason
+// that it has to be this way.
+const IntermediateParam = struct {
+    InputType: type,
+    OutputType: type,
+    in_field_name: [:0]const u8,
+    resolver: *anyopaque,
+};
+
+//Parameters can be either:
+// - Resolver functions which map from an input type to a config field
+// - Direct mappings from input parameters to config fields
+//   (in this case, "resolver" would be null.
 pub fn Parameter(
     comptime T: type,
     comptime field_name: [:0]const u8,
     comptime resolver: anytype,
-) ParameterDef {}
+) std.meta.Tuple(&.{ type, type, [:0]const u8, *anyopaque }) {
+    const ResolverType = @TypeOf(resolver);
+    const rinfo = @typeInfo(ResolverType);
+
+    const InputType, const res = switch (rinfo) {
+        .@"fn" => |f| blk: {
+            if (f.params.len != 1)
+                @compileError("Resolver functions must take a single argument");
+            const input_arg = f.params[0];
+
+            break :blk .{ input_arg.type, resolver };
+        },
+        .null => blk: {
+            const Container = struct {
+                pub fn noOp(in: T) T {
+                    return in;
+                }
+            };
+
+            break :blk .{ T, Container.noOp };
+        },
+        else => @compileError("resolver must be a function or null"),
+    };
+
+    return .{ T, InputType, field_name, res };
+}
+
+test "config (default value)" {}
+
+test "config (profile)" {}
+
+test "config (parameterized profile)" {}
+
+test "config (value composition)" {}

--- a/src/common/config.zig
+++ b/src/common/config.zig
@@ -1,10 +1,72 @@
 //! Configurations and stuff but cooler
 
+const std = @import("std");
+const util = @import("common.zig").util;
+
+fn validateProfiles(
+    comptime T: type, 
+    comptime Hint: type,
+) std.builtin.Type.Enum {
+    const pinfo = @typeInfo(T);
+    if (!pinfo == .@"enum")
+        @compileError("Invalid profile listing enum: " ++
+            @typeName(T) ++ " for config type: " ++ @typeName(Hint));
+
+    return pinfo.@"enum";
+}
+
+fn validateDef(
+    comptime T: type,
+    comptime def: anytype,
+    comptime Hint: type,
+) void {
+    const info = @typeInfo(@TypeOf(def));
+
+    switch (info) {
+        .@"struct" => |*s| {
+            const pinfo = @typeInfo(T).@"enum";
+            for (pinfo.fields) |fld| {
+                if (util.tryGetField(s, fld.name)) {
+                    @compileError("Profile def missing field: " ++
+                        fld.name ++ " for config type: " ++ @typeName(Hint));
+                }
+            }
+        },
+        else => @compileError("Invalid profile def struct: " ++
+            @typeName(T) ++ " for config type: " ++ @typeName(Hint)),
+    }
+}
+
 
 pub fn ConfigurationRegistry(
+    /// ConfigType can be any struct
     comptime ConfigType: type,
+    /// Profiles must be a packed, non-sparse enum, (preferably human readable)
     comptime Profiles: type,
+    /// profile_defs must be an anonymous struct literal
+    /// whose fields are named after the "Profile" enum fields
+    /// with an additional field called "Default" for the default configuration
+    /// Values can either be valid instances of the configuration struct type,
+    /// or one of the provided parameterization helper types
     comptime profile_defs: anytype,
 ) type {
+    const profile_info = validateProfiles(Profiles, ConfigType);
+    validateDef(Profiles, profile_defs, ConfigType);
 
+    const profiles_len = profile_info.fields.len;
 }
+
+pub fn Parameterized(
+    comptime instance: anytype,
+    comptime params: anytype,
+) @TypeOf(instance) {}
+
+fn ResolverFn(comptime T: type) type {}
+
+pub const ParameterDef = struct {};
+
+pub fn Parameter(
+    comptime T: type,
+    comptime field_name: [:0]const u8,
+    comptime resolver: anytype,
+) ParameterDef {}

--- a/src/common/util.zig
+++ b/src/common/util.zig
@@ -35,9 +35,9 @@ const StructField = std.builtin.Type.StructField;
 const Function = std.builtin.Type.Fn;
 
 // Reflection Stuff
-pub fn tryGetField(info: *StructInfo, name: []const u8) ?*StructField {
+pub fn tryGetField(info: *const StructInfo, name: []const u8) ?*const StructField {
     for (info.fields) |*fld| {
-        if (std.mem.eql(u8, fld.name, name) == .eq) {
+        if (std.mem.eql(u8, fld.name, name)) {
             return fld;
         }
     }

--- a/src/common/util.zig
+++ b/src/common/util.zig
@@ -1,0 +1,55 @@
+//! TODO: Merge this into the common directory
+//! Most of this is completely unused and useless, so 
+//! only a bit of this iwll be included...
+const std = @import("std");
+pub fn asCString(rep: anytype) [*:0]const u8 {
+    return @as([*:0]const u8, @ptrCast(rep));
+}
+
+pub fn emptySlice(comptime T: type) []T {
+    return &[0]T{};
+}
+
+//FIXME: This is due for a BIG REFACTOR COMING SOON
+// (because it is much worse than just &.{} which I Didn't know was a thing oops.
+pub fn asManyPtr(comptime T: type, ptr: *const T) [*]const T {
+    return @as([*]const T, @ptrCast(ptr));
+}
+
+//FIXME: This is due for a BIG REFACTOR COMING SOON
+// (because it is much worse than just &.{} which I Didn't know was a thing oops.
+// funilly enough, &.{1, 2, 3} is shorter than span(.{1, 2, 3}). I just don't 
+// like reading docs + idk how.
+pub fn span(v: anytype) [] @TypeOf(v[0]) {
+    const T = @TypeOf(v[0]);
+    comptime var sp: [v.len] T = undefined;
+    for (v, 0..) |val, index| {
+        sp[index] = val;
+    }
+
+    return sp[0..];
+}
+
+const StructInfo = std.builtin.Type.Struct;
+const StructField = std.builtin.Type.StructField;
+const Function = std.builtin.Type.Fn;
+
+// Reflection Stuff
+pub fn tryGetField(info: *StructInfo, name: []const u8) ?*StructField {
+    for (info.fields) |*fld| {
+        if (std.mem.eql(u8, fld.name, name) == .eq) {
+            return fld;
+        }
+    }
+
+    return null;
+}
+
+pub fn signatureMatches(a: *const Function, b: *const Function) bool {
+    if (a.params.len != b.params.len) return false;
+    for (a.params, b.params) |p1, p2|
+        if (p1.type != p2.type) return false;
+
+    if (!a.calling_convention.eql(b)) return false;
+    return true;
+}

--- a/src/resource_management/pool_allocator.zig
+++ b/src/resource_management/pool_allocator.zig
@@ -14,7 +14,7 @@
 //! which match vulkan object's lifetimes (generally they are the same per-type of object)
 
 const std = @import("std");
-const common = @import("../common/common.zig");
+const common = @import("common");
 const assert = std.debug.assert;
 
 const Allocator = std.mem.Allocator;

--- a/src/resource_management/registry.zig
+++ b/src/resource_management/registry.zig
@@ -5,7 +5,7 @@
 //! This is globally defined and not scoped to an application context
 const std = @import("std");
 
-const common = @import("../common/common.zig");
+const common = @import("common");
 const Context = @import("../context.zig");
 
 const Allocator = std.mem.Allocator;

--- a/src/resource_management/resource_manager.zig
+++ b/src/resource_management/resource_manager.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const Self = @This();
 
-const common = @import("../common/common.zig");
+const common = @import("common");
 const Registry = @import("registry.zig");
 
 const PoolAllocator = @import("pool_allocator.zig");

--- a/src/root.zig
+++ b/src/root.zig
@@ -6,7 +6,8 @@ pub const api = @import("api/api.zig");
 // Linear algebra math
 pub const math = @import("math.zig");
 
-// random common utilities (i.e: "misc")
+//TODO: replace the shitty utils with common
+pub const common = @import("common");
 pub const util = @import("util.zig");
 
 // Resource manager NOTE: (not sure if this should be exported tbh)

--- a/src/util.zig
+++ b/src/util.zig
@@ -35,7 +35,7 @@ const StructField = std.builtin.Type.StructField;
 const Function = std.builtin.Type.Fn;
 
 // Reflection Stuff
-pub fn tryGetField(info: *StructInfo, name: []const u8) ?*StructField {
+pub fn tryGetField(info: *const StructInfo, name: []const u8) ?*StructField {
     for (info.fields) |*fld| {
         if (std.mem.eql(u8, fld.name, name) == .eq) {
             return fld;


### PR DESCRIPTION
# Overview
Implemented config profiles, which should alleviate the extensive boilerplate involved in setting up and configuring vulkan objects whose function signatures would otherwise have parameter counts in the dozens.

## Changelog
* Implemented compile-time generated configuration registries, which may be used to define profiles (default initializers) for any struct.
* Allowed for parameterization of profiles (since many values can't be statically defined at comptime and arbitrary parameter mappings from profile parameter to field values.
* Implemented config builders, an easy way to combine predefined profiles with each other as well as literal values.

## Current Status
I would say this branch still needs a bit of cleaning up along with an extra look over since I'm sure I'm not handling some cases somewhere in the config code. Although I did end up introducing the almost hilariously ridiculous idea of "configging the configs" to this codebase, I think it really does do wonders for lowering the amount of boilerplate where it really counts. 

I am somewhat apprehensive about the potential slowdowns introduced by all the intermediary function calls for field mapping functions. so the user end may change if that ever becomes a significant bottleneck.

## Possible Expansions:
* **Function resolvers:** (rather than populating with individual field functions, just have a single function that produces a complete config) -- this is probably not super necessary as of now
* **Integration with context and environments:** This could reduce boilerplate from some to none if the runtime values that need to be populated via parameterization could be fed in by the context (at least to some level) -- worth looking into.
**See #17 for more details surrounding the features and motivations**